### PR TITLE
[#13] Added State value to all return values of init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ Types:
 <a name="callbacks"></a>
 #### Callbacks
 
-##### init(InitArgs, LastEventId, Req) -> {ok, NewReq, State} | {no_content, NewReq} | {shutdown, StatusCode, Headers, Body, NewReq}
+##### init(InitArgs, LastEventId, Req) -> {ok, NewReq, State}
+    | {no_content, NewReq, State}
+    | {shutdown, StatusCode, Headers, Body, NewReq, State}
 
 Will be called upon initialization of the handler, receiving the value of the ``"last-event-id"`` header
 if there is one and ``undefined`` otherwise. If everything goes well it should return
 ``{ok, NewReq, State}`` to leave the connection open. In case the handler has no content to deliver
-it should return ``{no_content, NewReq}`` and the client will receive a response with a status code ``204 No Content``.
-A custom response can be provided for other scenarios by returning ``{shutdown, StatusCode, Headers, Body, NewReq}``,
+it should return ``{no_content, NewReq, State}`` and the client will receive a response with a status code ``204 No Content``.
+A custom response can be provided for other scenarios by returning ``{shutdown, StatusCode, Headers, Body, NewReq, State}``,
 which will cause the handler to reply to the client with the information supplied and then terminate.
 
 Types:
@@ -115,7 +117,7 @@ Types:
 The field 'data' is required for every event returned by ``handle_notify()`` and ``hanfle_info()``,
 if one is not supplied a ``data_required`` will be thrown.
 
-##### event_value() :: {'id', binary()}
+##### event_value() = {'id', binary()}
     | {'event', binary()}
     | {'data', binary()}
     | {'retry', binary()}

--- a/src/lasse_handler.erl
+++ b/src/lasse_handler.erl
@@ -126,14 +126,14 @@ handle_init({ok, Req, State}, Module) ->
             cowboy_req:reply(StatusCode, Headers, Req),
             {shutdown, Req, #state{module = Module}}
     end;
-handle_init({no_content, NewReq}, Module) ->
+handle_init({no_content, NewReq, State}, Module) ->
     cowboy_req:reply(204, [], NewReq),
 
-    {shutdown, NewReq, #state{module = Module}};
-handle_init({shutdown, StatusCode, Headers, Body, NewReq}, Module) ->
+    {shutdown, NewReq, #state{module = Module, state = State}};
+handle_init({shutdown, StatusCode, Headers, Body, NewReq, State}, Module) ->
     cowboy_req:reply(StatusCode, Headers, Body, NewReq),
 
-    {shutdown, NewReq, #state{module = Module}}.
+    {shutdown, NewReq, #state{module = Module, state = State}}.
 
 process_result({send, Event, NewState}, Req, State) ->
     EventMsg = build_event(Event),

--- a/test/no_content_handler.erl
+++ b/test/no_content_handler.erl
@@ -10,7 +10,7 @@
         ]).
 
 init(_InitArgs, _LastEventId, Req) ->
-    {no_content, Req}.
+    {no_content, Req, {}}.
 
 handle_info(_, _) ->
     does_not_matter.

--- a/test/shutdown_handler.erl
+++ b/test/shutdown_handler.erl
@@ -12,7 +12,7 @@
 init(_InitArgs, _LastEventId, Req) ->
     Headers = [{<<"content-type">>, <<"text/html">>}],
     Body = <<"Sorry, shutdown!">>,
-    {shutdown, 404, Headers, Body, Req}.
+    {shutdown, 404, Headers, Body, Req, {}}.
 
 handle_info(Msg, State) ->
     {send, [{data, Msg}], State}.


### PR DESCRIPTION
The  `terminate()` callback takes the implementing module state, but some of the values returned from `init()` didn't provide one, so they were modify to do this. The README was updated accordingly.
