### PR TITLE
Fix result handling of module:handle_error/3

### DIFF
--- a/src/lasse_handler.erl
+++ b/src/lasse_handler.erl
@@ -148,7 +148,7 @@ process_result({send, Event, NewState}, Req, State) ->
             Module = State#state.module,
             ModuleState = State#state.state,
             ErrorNewState = Module:handle_error(Event, Reason, ModuleState),
-            {ok, Req, State#state{module = ErrorNewState}};
+            {ok, Req, State#state{state = ErrorNewState}};
         ok ->
             {loop, Req, State#state{state = NewState}}
     end;


### PR DESCRIPTION
In `process_result/3`, the result of `Module:handle_error/3` should be updated to the `state` field instead of `module`.
